### PR TITLE
Remove `dim` before putting the list-col in a tibble

### DIFF
--- a/R/rainette2.R
+++ b/R/rainette2.R
@@ -205,6 +205,7 @@ get_optimal_partitions <- function(partitions, cross_groups, n_tot, full) {
       if (is.null(partition)) {
         return(NULL)
       }
+      dim(partition) <- NULL
       out <- dplyr::tibble(clusters = partition, k = k + 1) %>%
         dplyr::rowwise() %>%
         ## Compute size and sum of Khi2 for each partition


### PR DESCRIPTION
We are working on the next vctrs release, targeted for Jan 15, and this package came up in our revdep analysis.

`vctrs::obj_is_list()` no longer returns `TRUE` for _list arrays_, which means that `dplyr::rowwise()` no longer sees this as a kind of list that it can do special rowwise-indexing on. Instead, you need to remove the dim attribute first to make it a vector list rather than an array list.

If you could please do a patch release before Jan 15, that would make it easier for us, thanks!